### PR TITLE
Feat/vote bulk api

### DIFF
--- a/src/main/java/online/pictz/api/choice/entity/Choice.java
+++ b/src/main/java/online/pictz/api/choice/entity/Choice.java
@@ -40,7 +40,7 @@ public class Choice {
         this.voteCount = 0;
     }
 
-    public void incrementVoteCount() {
-        this.voteCount += 1;
+    public void updateVoteCount(int voteCount) {
+        this.voteCount += voteCount;
     }
 }

--- a/src/main/java/online/pictz/api/common/exception/domain/ErrorType.java
+++ b/src/main/java/online/pictz/api/common/exception/domain/ErrorType.java
@@ -15,7 +15,8 @@ public enum ErrorType {
     FORBIDDEN("E_403", "Forbidden"),
     PAGE_NOT_FOUND("E_404", "Page Not found"),
     CONFLICT("E_409", "Conflict"),
-    RESOURCE_NOT_FOUND("E_404", "Resource Not Found");
+    RESOURCE_NOT_FOUND("E_404", "Resource Not Found"),
+    TOO_MANY_REQUESTS("E_429", "Too Many Requests");
 
     private final String code;
     private final String message;

--- a/src/main/java/online/pictz/api/vote/controller/VoteApiController.java
+++ b/src/main/java/online/pictz/api/vote/controller/VoteApiController.java
@@ -1,10 +1,9 @@
 package online.pictz.api.vote.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import online.pictz.api.vote.dto.VoteCreate;
-import online.pictz.api.vote.dto.VoteResponse;
+import online.pictz.api.vote.dto.VoteRequest;
 import online.pictz.api.vote.service.VoteService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,10 +17,13 @@ public class VoteApiController {
 
     private final VoteService voteService;
 
-    @PostMapping
-    public ResponseEntity<VoteResponse> createVote(@RequestBody VoteCreate voteCreate) {
-        VoteResponse voteResponse = voteService.createVote(voteCreate);
-        return ResponseEntity.status(HttpStatus.CREATED).body(voteResponse);
+    /**
+     * 투표 일괄 처리
+     */
+    @PostMapping("/bulk")
+    public ResponseEntity<Void> voteBulk(@RequestBody List<VoteRequest> voteRequest) {
+        voteService.voteBulk(voteRequest);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/online/pictz/api/vote/dto/VoteRequest.java
+++ b/src/main/java/online/pictz/api/vote/dto/VoteRequest.java
@@ -2,11 +2,14 @@ package online.pictz.api.vote.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class VoteCreate {
+public class VoteRequest {
 
     private Long choiceId;
+    private int count;
 
 }

--- a/src/main/java/online/pictz/api/vote/entity/Vote.java
+++ b/src/main/java/online/pictz/api/vote/entity/Vote.java
@@ -20,20 +20,23 @@ public class Vote {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "choice_id")
+    @Column(name = "choice_id", nullable = false)
     private Long choiceId;
 
-    @Column(name = "ip")
+    @Column(name = "ip", nullable = false)
     private String ip;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+    @Column(name = "voted_at", nullable = false)
+    private LocalDateTime votedAt;
+
+    private int count;
 
     @Builder
-    public Vote(Long choiceId, String ip, LocalDateTime createdAt) {
+    public Vote(Long choiceId, String ip, LocalDateTime votedAt, int count) {
         this.choiceId = choiceId;
         this.ip = ip;
-        this.createdAt = createdAt;
+        this.votedAt = votedAt;
+        this.count = count;
     }
 
     protected Vote() {}

--- a/src/main/java/online/pictz/api/vote/exception/VoteTooManyRequests.java
+++ b/src/main/java/online/pictz/api/vote/exception/VoteTooManyRequests.java
@@ -1,0 +1,27 @@
+package online.pictz.api.vote.exception;
+
+import online.pictz.api.common.exception.domain.ErrorType;
+import online.pictz.api.common.exception.domain.PictzException;
+import org.springframework.http.HttpStatus;
+
+public class VoteTooManyRequests extends PictzException {
+
+    protected VoteTooManyRequests(String message) {
+        super(message);
+    }
+
+    public static VoteTooManyRequests of(int voteCount) {
+        return new VoteTooManyRequests("Too many vote requests : " + voteCount);
+    }
+
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.TOO_MANY_REQUESTS;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ErrorType.TOO_MANY_REQUESTS.getCode();
+    }
+}

--- a/src/main/java/online/pictz/api/vote/service/VoteConverter.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteConverter.java
@@ -1,0 +1,53 @@
+package online.pictz.api.vote.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import online.pictz.api.vote.dto.VoteRequest;
+import online.pictz.api.vote.entity.Vote;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VoteConverter {
+
+    /**
+     * 투표 요청한 선택지 ID 값 목록 추출
+     */
+    public List<Long> convertToChoiceIds(List<VoteRequest> voteRequests) {
+        return voteRequests.stream()
+            .map(VoteRequest::getChoiceId)
+            .toList();
+    }
+
+    /**
+     * 투표 정보 목록 entity 로 변환
+     */
+    public List<Vote> convertToVoteEntities(List<VoteRequest> voteRequests, String ip, LocalDateTime voteAt) {
+        List<Vote> votesToSave = new ArrayList<>();
+        for (VoteRequest vote : voteRequests) {
+            Vote voteEntity = Vote.builder()
+                .choiceId(vote.getChoiceId())
+                .count(vote.getCount())
+                .ip(ip)
+                .votedAt(voteAt)
+                .build();
+            votesToSave.add(voteEntity);
+        }
+        return votesToSave;
+    }
+
+    /**
+     * choiceId 별 투표 회수 Map 생성
+     */
+    public Map<Long, Integer> convertToVoteCountMap(List<VoteRequest> voteRequests) {
+        Map<Long, Integer> voteCountMap = new ConcurrentHashMap<>();
+        for (VoteRequest vote : voteRequests) {
+            voteCountMap.put(vote.getChoiceId(), vote.getCount());
+        }
+        return voteCountMap;
+    }
+
+
+}

--- a/src/main/java/online/pictz/api/vote/service/VoteService.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteService.java
@@ -1,8 +1,10 @@
 package online.pictz.api.vote.service;
 
-import online.pictz.api.vote.dto.VoteCreate;
-import online.pictz.api.vote.dto.VoteResponse;
+import java.util.List;
+import online.pictz.api.vote.dto.VoteRequest;
 
 public interface VoteService {
-    VoteResponse createVote(VoteCreate voteCreate);
+
+    void voteBulk(List<VoteRequest> voteRequest);
+
 }

--- a/src/main/java/online/pictz/api/vote/service/VoteServiceImpl.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteServiceImpl.java
@@ -1,15 +1,18 @@
 package online.pictz.api.vote.service;
 
+
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import online.pictz.api.choice.entity.Choice;
-import online.pictz.api.choice.exception.ChoiceNotFound;
 import online.pictz.api.choice.repository.ChoiceRepository;
 import online.pictz.api.common.util.network.IpExtractor;
-import online.pictz.api.vote.dto.VoteCreate;
-import online.pictz.api.vote.dto.VoteResponse;
+import online.pictz.api.common.util.time.TimeProvider;
+import online.pictz.api.vote.dto.VoteRequest;
 import online.pictz.api.vote.entity.Vote;
 import online.pictz.api.vote.repository.VoteRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -18,25 +21,37 @@ public class VoteServiceImpl implements VoteService{
     private final VoteRepository voteRepository;
     private final ChoiceRepository choiceRepository;
     private final IpExtractor ipExtractor;
+    private final TimeProvider timeProvider;
+    private final VoteConverter voteConverter;
+    private final VoteValidator voteValidator;
 
+    @Transactional
     @Override
-    public VoteResponse createVote(VoteCreate voteCreate) {
+    public void voteBulk(List<VoteRequest> voteRequests) {
 
-        Choice choice = choiceRepository.findById(voteCreate.getChoiceId())
-            .orElseThrow(() -> ChoiceNotFound.forChoiceId(voteCreate.getChoiceId()));
+        // 매크로 검증
+        voteValidator.validateVoteMacro(voteRequests);
 
-        choice.incrementVoteCount();
-        choiceRepository.save(choice);
+        // 요청한 선택지 ID 값 목록 추출
+        List<Long> choiceIds = voteConverter.convertToChoiceIds(voteRequests);
+        List<Choice> choices = choiceRepository.findAllById(choiceIds);
 
-        String ipAddress = ipExtractor.extractIp();
+        // 투표 수 choice ID에 맞게 업데이트
+        Map<Long, Integer> voteCountMap = voteConverter.convertToVoteCountMap(voteRequests);
 
-        Vote vote = Vote.builder()
-            .choiceId(voteCreate.getChoiceId())
-            .ip(ipAddress)
-            .build();
+        choices.forEach(choice -> {
+            int countToAdd = voteCountMap.getOrDefault(choice.getId(),0);
+            choice.updateVoteCount(countToAdd);
+        });
 
-        voteRepository.save(vote);
+        choiceRepository.saveAll(choices);
 
-        return new VoteResponse(choice.getId(), choice.getVoteCount());
+        // 투표 정보 저장
+        String ip = ipExtractor.extractIp();
+        List<Vote> votesToSave = voteConverter.convertToVoteEntities(voteRequests, ip, timeProvider.getCurrentTime());
+
+        voteRepository.saveAll(votesToSave);
+
     }
+
 }

--- a/src/main/java/online/pictz/api/vote/service/VoteValidator.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteValidator.java
@@ -1,0 +1,29 @@
+package online.pictz.api.vote.service;
+
+import java.util.List;
+import online.pictz.api.vote.dto.VoteRequest;
+import online.pictz.api.vote.exception.VoteTooManyRequests;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VoteValidator {
+
+    private static final int MAX_ALLOWED_VOTE_COUNT = 300;
+
+    /**
+     * 비정상적인 투표 클릭 횟수 매크로 감지
+     */
+    public void validateVoteMacro(List<VoteRequest> voteRequests) {
+
+        int totalVoteCount = 0;
+
+        for(VoteRequest voteRequest : voteRequests) {
+            totalVoteCount += voteRequest.getCount();
+        }
+
+        if (totalVoteCount > MAX_ALLOWED_VOTE_COUNT) {
+            throw VoteTooManyRequests.of(totalVoteCount);
+        }
+    }
+
+}

--- a/src/test/java/online/pictz/api/vote/controller/VoteApiControllerTest.java
+++ b/src/test/java/online/pictz/api/vote/controller/VoteApiControllerTest.java
@@ -1,19 +1,10 @@
 package online.pictz.api.vote.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
-import online.pictz.api.vote.dto.VoteCreate;
-import online.pictz.api.vote.dto.VoteResponse;
 import online.pictz.api.vote.service.VoteService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
 class VoteApiControllerTest {
@@ -24,25 +15,5 @@ class VoteApiControllerTest {
     @InjectMocks
     private VoteApiController voteApiController;
 
-    @DisplayName("투표 생성 성공")
-    @Test
-    void createVote_SUCCESS() {
-
-        // given
-        var choiceId = 1L;
-        VoteCreate voteCreateRequest = new VoteCreate(choiceId);
-        VoteResponse voteCreateResponse = new VoteResponse(choiceId, 999);
-
-        when(voteService.createVote(voteCreateRequest)).thenReturn(voteCreateResponse);
-
-        // when
-        ResponseEntity<VoteResponse> apiResult = voteApiController.createVote(voteCreateRequest);
-
-        // then
-        assertThat(apiResult.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(apiResult.getBody().getChoiceId()).isEqualTo(1L);
-        assertThat(apiResult.getBody().getVoteCount()).isEqualTo(999);
-        assertThat(voteCreateResponse).isEqualTo(apiResult.getBody());
-    }
 
 }

--- a/src/test/java/online/pictz/api/vote/service/VoteServiceImplTest.java
+++ b/src/test/java/online/pictz/api/vote/service/VoteServiceImplTest.java
@@ -1,86 +1,11 @@
 package online.pictz.api.vote.service;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
 
-import java.util.Optional;
-import online.pictz.api.choice.entity.Choice;
-import online.pictz.api.choice.exception.ChoiceNotFound;
-import online.pictz.api.choice.repository.ChoiceRepository;
-import online.pictz.api.common.util.network.IpExtractor;
-import online.pictz.api.vote.dto.VoteCreate;
-import online.pictz.api.vote.dto.VoteResponse;
-import online.pictz.api.mock.FakeIpExtractor;
-import online.pictz.api.vote.repository.VoteRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 
 @ExtendWith(MockitoExtension.class)
 class VoteServiceImplTest {
 
-    @Mock
-    private VoteRepository voteRepository;
 
-    @Mock
-    private ChoiceRepository choiceRepository;
-
-    private IpExtractor ipExtractor;
-
-    private VoteServiceImpl voteService;
-
-    @BeforeEach
-    public void setUp() {
-        ipExtractor = new FakeIpExtractor("1.1.1.1");
-        voteService = new VoteServiceImpl(voteRepository, choiceRepository, ipExtractor);
-    }
-
-
-    @DisplayName("투표 생성 성공 후 choice의 투표 count는 1이다")
-    @Test
-    void createVote_SUCCESS() {
-
-        // given
-        var choiceId = 1L;
-        VoteCreate voteCreate = new VoteCreate(choiceId);
-
-        Choice choice = new Choice(1L, "메호대전", "선택지 썸네일 URL");
-        when(choiceRepository.findById(anyLong())).thenReturn(Optional.of(choice));
-
-        // when
-        VoteResponse voteResponse = voteService.createVote(voteCreate);
-
-        // then
-        assertThat(voteResponse.getVoteCount()).isEqualTo(1);
-
-    }
-
-    @DisplayName("투표 하려는 choice가 존재하지 않을 경우 예외 발생")
-    @Test
-    void createVoid_FAIL_When_choice_is_not_exists() {
-
-        // given
-        var choiceId = 9999L;
-        VoteCreate voteCreate = new VoteCreate(choiceId);
-
-        when(choiceRepository.findById(choiceId)).thenReturn(Optional.empty());
-
-        // when
-        ChoiceNotFound exception = assertThrows(
-            ChoiceNotFound.class,
-            () -> voteService.createVote(voteCreate)
-        );
-
-        // then
-        assertThat(exception.getErrorCode()).isEqualTo("E_404");
-        assertThat(exception.getMessage()).isEqualTo("No choice found with ID: 9999");
-        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.NOT_FOUND);
-
-    }
 }


### PR DESCRIPTION
## Updated
- 투표 단일건 처리에서 벌크 처리로 변경
- 한번에 많은 투표요청오면 매크로 예외 
- 추후 시간마다 요청 보내는 매크로 차단하기 위해 vote 엔티티에 count 컬럼 추가

## TODO
- 변경된 투표 로직에 따라 테스트 코드 작성