### PR TITLE
refactor/투표 동시성 해결 1차 - synchronized

### DIFF
--- a/src/main/java/online/pictz/api/vote/service/VoteServiceImpl.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteServiceImpl.java
@@ -27,7 +27,7 @@ public class VoteServiceImpl implements VoteService{
 
     @Transactional
     @Override
-    public void voteBulk(List<VoteRequest> voteRequests) {
+    public synchronized void voteBulk(List<VoteRequest> voteRequests) {
 
         // 매크로 검증
         voteValidator.validateVoteMacro(voteRequests);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true

--- a/src/test/java/online/pictz/api/mock/TestIpExtractor.java
+++ b/src/test/java/online/pictz/api/mock/TestIpExtractor.java
@@ -2,11 +2,11 @@ package online.pictz.api.mock;
 
 import online.pictz.api.common.util.network.IpExtractor;
 
-public class FakeIpExtractor implements IpExtractor {
+public class TestIpExtractor implements IpExtractor {
 
     private final String fixedIp;
 
-    public FakeIpExtractor(String fixedIp) {
+    public TestIpExtractor(String fixedIp) {
         this.fixedIp = fixedIp;
     }
 

--- a/src/test/java/online/pictz/api/vote/service/VoteServiceImplTest.java
+++ b/src/test/java/online/pictz/api/vote/service/VoteServiceImplTest.java
@@ -1,11 +1,105 @@
 package online.pictz.api.vote.service;
 
 
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@ExtendWith(MockitoExtension.class)
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import online.pictz.api.choice.entity.Choice;
+import online.pictz.api.choice.repository.ChoiceRepository;
+import online.pictz.api.mock.TestIpExtractor;
+import online.pictz.api.mock.TestTimeProvider;
+import online.pictz.api.vote.dto.VoteRequest;
+import online.pictz.api.vote.repository.VoteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
 class VoteServiceImplTest {
+
+    @Autowired
+    private ChoiceRepository choiceRepository;
+
+    @Autowired
+    private VoteRepository voteRepository;
+
+    private VoteServiceImpl voteService;
+
+    @BeforeEach
+    void setUp() {
+
+        voteService = new VoteServiceImpl(
+            voteRepository,
+            choiceRepository,
+            new TestIpExtractor("1.1.1.1"),
+            new TestTimeProvider(LocalDateTime.of(2024, 1, 1, 0, 0, 0)),
+            new VoteConverter(),
+            new VoteValidator()
+        );
+
+        Choice choice1 = new Choice(1L, "메시", "메시 이미지");
+        Choice choice2 = new Choice(1L, "호날두", "호날두 이미지");
+        choiceRepository.saveAll(List.of(choice1, choice2));
+    }
+
+    @DisplayName("동시에 다수가 투표하더라도 모두 업데이트 되어야 한다")
+    @Test
+    void voteBulk() throws InterruptedException{
+
+        // 3명의 유저가 있다고 가정
+        int userCount = 50;
+
+        // ThreadPool 크기
+        int threadPoolSize = 32;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize);
+        CountDownLatch latch = new CountDownLatch(userCount);
+
+        // given
+        int tenVotes = 10;
+        int twoVotes = 20;
+
+        Long messiChoiceId = 1L;
+        Long ronaldoChoiceId = 2L;
+
+        List<VoteRequest> request = List.of(
+            new VoteRequest(messiChoiceId, tenVotes),
+            new VoteRequest(ronaldoChoiceId, twoVotes)
+        );
+
+        for (int i = 0; i < userCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    // when
+                    voteService.voteBulk(request);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        int expectedVoteCountForMessi = userCount * tenVotes;    // 실시간 투표 유저 수 * 투표한 count 수 (50 * 2 = 100)
+        int expectedVoteCountForRonaldo = userCount * twoVotes;   // 실시간 투표 유저 수 * 투표한 count 수 (50 * 4 = 200)
+
+        Choice messiChoice = choiceRepository.findById(messiChoiceId).orElseThrow();
+        Choice ronaldoChoice = choiceRepository.findById(ronaldoChoiceId).orElseThrow();
+
+        assertThat(messiChoice.getVoteCount()).isEqualTo(expectedVoteCountForMessi);
+        assertThat(ronaldoChoice.getVoteCount()).isEqualTo(expectedVoteCountForRonaldo);
+
+
+        executorService.shutdown();
+    }
 
 
 }


### PR DESCRIPTION
현재 동시 투표 요청이 올 경우 동시성 문제로 인해 투표수가 제대로 update되지 않는다
그래서 synchronized를 이용해 해결 했지만, 여전히 성능, 서버가 늘어나면 문제점이 있다

#30