### PR TITLE
refactor/투표 동시성 해결 2차 - optimization #31

### DIFF
--- a/src/main/java/online/pictz/api/choice/entity/Choice.java
+++ b/src/main/java/online/pictz/api/choice/entity/Choice.java
@@ -6,6 +6,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Version;
 import lombok.Getter;
 
 @Getter
@@ -28,6 +29,9 @@ public class Choice {
 
     @Column(name = "vote_count", columnDefinition = "INT default 0")
     private int voteCount;
+
+    @Version
+    private int version;
 
     protected Choice() {
 

--- a/src/main/java/online/pictz/api/vote/exception/VoteTooManyRequests.java
+++ b/src/main/java/online/pictz/api/vote/exception/VoteTooManyRequests.java
@@ -14,6 +14,10 @@ public class VoteTooManyRequests extends PictzException {
         return new VoteTooManyRequests("Too many vote requests : " + voteCount);
     }
 
+    public static VoteTooManyRequests of(String message) {
+        return new VoteTooManyRequests("Too many vote request at the same time : " + message);
+    }
+
 
     @Override
     public HttpStatus getHttpStatus() {

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -5,14 +5,14 @@ VALUES (1, NULL, '메시 VS 호날두', 'messi-vs-ronaldo', 'ACTIVE', 'https://i
        (3, NULL, '짬뽕 VS 짜장면', 'jjamppong-vs-jjajang', 'ACTIVE', 'https://i.ytimg.com/vi/xhc5Ds-3ahM/maxresdefault.jpg',  now(), now(), NULL);
 
 -- Choice 초기 데이터
-INSERT INTO choice (id, topic_id, name, image_url, vote_count)
-VALUES (1, 1, '메시', 'https://fifpro.org/media/5chb3dva/lionel-messi_imago1019567000h.jpg?rxy=0.32986930611281567,0.18704579979466449&rnd=133378758718600000', 0),
-       (2, 1, '호날두', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQb-NGEQDekk2BwsllLjk4tcIM_BPIzXECdsg&s', 0),
-       (3, 2, '카리나', 'https://i.pinimg.com/736x/fa/ee/75/faee75d38f6636b81ad9ceacd9163a45.jpg', 0),
-       (4, 2, '장원영', 'https://upload.wikimedia.org/wikipedia/commons/e/ee/2023_MMA_IVE_Wonyoung_1.jpg', 0),
-       (5, 2, '설윤', 'https://blog.kakaocdn.net/dn/15c1u/btrBF5rq2s1/uCDT0O1GSpm5WEu8kHzna0/img.jpg', 0),
-       (6, 2, '유나', 'https://dispatch.cdnser.be/cms-content/uploads/2023/10/26/34d8a288-ba3a-49ca-91da-767f69d03f5e.jpg', 0),
-       (7, 3, '짬뽕', 'https://img.siksinhot.com/article/1520236678174003.jpg', 0),
-       (8, 3, '짜장면', 'https://img.siksinhot.com/place/1687310897617109.jpg?c=Y', 0);
+INSERT INTO choice (id, topic_id, name, image_url, vote_count, version)
+VALUES (1, 1, '메시', 'https://fifpro.org/media/5chb3dva/lionel-messi_imago1019567000h.jpg?rxy=0.32986930611281567,0.18704579979466449&rnd=133378758718600000', 0, 0),
+       (2, 1, '호날두', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQb-NGEQDekk2BwsllLjk4tcIM_BPIzXECdsg&s', 0, 0),
+       (3, 2, '카리나', 'https://i.pinimg.com/736x/fa/ee/75/faee75d38f6636b81ad9ceacd9163a45.jpg', 0, 0),
+       (4, 2, '장원영', 'https://upload.wikimedia.org/wikipedia/commons/e/ee/2023_MMA_IVE_Wonyoung_1.jpg', 0, 0),
+       (5, 2, '설윤', 'https://blog.kakaocdn.net/dn/15c1u/btrBF5rq2s1/uCDT0O1GSpm5WEu8kHzna0/img.jpg', 0, 0),
+       (6, 2, '유나', 'https://dispatch.cdnser.be/cms-content/uploads/2023/10/26/34d8a288-ba3a-49ca-91da-767f69d03f5e.jpg', 0, 0),
+       (7, 3, '짬뽕', 'https://img.siksinhot.com/article/1520236678174003.jpg', 0, 0),
+       (8, 3, '짜장면', 'https://img.siksinhot.com/place/1687310897617109.jpg?c=Y', 0, 0);
 
 

--- a/src/test/java/online/pictz/api/vote/service/VoteServiceImplIntegrationTest.java
+++ b/src/test/java/online/pictz/api/vote/service/VoteServiceImplIntegrationTest.java
@@ -21,9 +21,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+/**
+ * 통합 테스트
+ */
 @ActiveProfiles("test")
 @SpringBootTest
-class VoteServiceImplTest {
+class VoteServiceImplIntegrationTest {
 
     @Autowired
     private ChoiceRepository choiceRepository;
@@ -52,9 +55,9 @@ class VoteServiceImplTest {
 
     @DisplayName("동시에 다수가 투표하더라도 모두 업데이트 되어야 한다")
     @Test
-    void voteBulk() throws InterruptedException{
+    void voteBulk() throws InterruptedException {
 
-        // 3명의 유저가 있다고 가정
+        // 50명의 유저가 있다고 가정
         int userCount = 50;
 
         // ThreadPool 크기
@@ -77,8 +80,10 @@ class VoteServiceImplTest {
         for (int i = 0; i < userCount; i++) {
             executorService.submit(() -> {
                 try {
-                    // when
                     voteService.voteBulk(request);
+                } catch (Exception e) {
+                    // 예외 로그 기록
+                    e.printStackTrace();
                 } finally {
                     latch.countDown();
                 }
@@ -88,8 +93,10 @@ class VoteServiceImplTest {
         latch.await();
 
         // then
-        int expectedVoteCountForMessi = userCount * tenVotes;    // 실시간 투표 유저 수 * 투표한 count 수 (50 * 2 = 100)
-        int expectedVoteCountForRonaldo = userCount * twoVotes;   // 실시간 투표 유저 수 * 투표한 count 수 (50 * 4 = 200)
+        int expectedVoteCountForMessi =
+            userCount * tenVotes;    // 실시간 투표 유저 수 * 투표한 count 수 (50 * 10 = 500)
+        int expectedVoteCountForRonaldo =
+            userCount * twoVotes;   // 실시간 투표 유저 수 * 투표한 count 수 (50 * 4 = 1000)
 
         Choice messiChoice = choiceRepository.findById(messiChoiceId).orElseThrow();
         Choice ronaldoChoice = choiceRepository.findById(ronaldoChoiceId).orElseThrow();
@@ -97,9 +104,7 @@ class VoteServiceImplTest {
         assertThat(messiChoice.getVoteCount()).isEqualTo(expectedVoteCountForMessi);
         assertThat(ronaldoChoice.getVoteCount()).isEqualTo(expectedVoteCountForRonaldo);
 
-
         executorService.shutdown();
     }
-
 
 }


### PR DESCRIPTION
현재 동시 투표 요청이 올 경우 동시성 문제로 인해 투표수가 제대로 update되지 않는다
낙관적락을 이용해 해결
하지만 충돌이 여러번 발생할 경우 여전히 성능상 문제가 발생할 것으로 예상
모니터링을 통해 Retry횟수를 조정하던지 아니면 중간에 Redis를 두어서 해결해야 될수도있음
#30