### PR TITLE
feat/random nickname api

### DIFF
--- a/src/main/java/online/pictz/api/common/config/RestTemplateConfig.java
+++ b/src/main/java/online/pictz/api/common/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package online.pictz.api.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+}

--- a/src/main/java/online/pictz/api/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/online/pictz/api/common/resolver/CurrentUserArgumentResolver.java
@@ -39,7 +39,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
         if (principal instanceof CustomOAuth2User) {
             CustomOAuth2User customUser = (CustomOAuth2User) principal;
-            return new UserDto(customUser.getSiteUserId(), customUser.getProviderId());
+            return new UserDto(customUser.getSiteUserId(), customUser.getName());
         }
 
         throw UserUnauthorized.of();

--- a/src/main/java/online/pictz/api/common/util/random/SuffixGenerator.java
+++ b/src/main/java/online/pictz/api/common/util/random/SuffixGenerator.java
@@ -1,0 +1,7 @@
+package online.pictz.api.common.util.random;
+
+public interface SuffixGenerator {
+
+    String generateSuffix();
+
+}

--- a/src/main/java/online/pictz/api/common/util/random/impl/RandomNumberSuffixGenerator.java
+++ b/src/main/java/online/pictz/api/common/util/random/impl/RandomNumberSuffixGenerator.java
@@ -1,0 +1,18 @@
+package online.pictz.api.common.util.random.impl;
+
+import java.util.Random;
+import online.pictz.api.common.util.random.SuffixGenerator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RandomNumberSuffixGenerator implements SuffixGenerator {
+
+    private final Random random = new Random();
+
+    // 6자리 랜덤 숫자 생성
+    @Override
+    public String generateSuffix() {
+        return "#" + String.format("%06d", random.nextInt(1000000));
+    }
+
+}

--- a/src/main/java/online/pictz/api/user/controller/UserApiController.java
+++ b/src/main/java/online/pictz/api/user/controller/UserApiController.java
@@ -1,0 +1,21 @@
+package online.pictz.api.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import online.pictz.api.common.annotation.CurrentUser;
+import online.pictz.api.user.dto.UserDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+@RestController
+public class UserApiController {
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto> me(@CurrentUser UserDto userDto) {
+        return ResponseEntity.ok(userDto);
+    }
+
+}

--- a/src/main/java/online/pictz/api/user/dto/UserDto.java
+++ b/src/main/java/online/pictz/api/user/dto/UserDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserDto {
     private final Long id;
-    private final String providerId;
+    private final String nickname;
 }

--- a/src/main/java/online/pictz/api/user/entity/CustomOAuth2User.java
+++ b/src/main/java/online/pictz/api/user/entity/CustomOAuth2User.java
@@ -10,18 +10,16 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class CustomOAuth2User implements OAuth2User {
 
     private final SiteUser siteUser;
-    private final Map<String, Object> attributes;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public CustomOAuth2User(SiteUser siteUser, Map<String, Object> attributes) {
+    public CustomOAuth2User(SiteUser siteUser) {
         this.siteUser = siteUser;
-        this.attributes = Collections.unmodifiableMap(attributes);
         this.authorities = Collections.singleton(new SimpleGrantedAuthority(siteUser.getRole().name()));
     }
 
     @Override
     public Map<String, Object> getAttributes() {
-        return attributes;
+        return Collections.emptyMap();
     }
 
     @Override
@@ -31,7 +29,7 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public String getName() {
-        return siteUser.getProviderId();
+        return siteUser.getNickname();
     }
 
     public Long getSiteUserId() {
@@ -41,4 +39,5 @@ public class CustomOAuth2User implements OAuth2User {
     public String getProviderId() {
         return siteUser.getProviderId();
     }
+
 }

--- a/src/main/java/online/pictz/api/user/entity/SiteUser.java
+++ b/src/main/java/online/pictz/api/user/entity/SiteUser.java
@@ -22,13 +22,17 @@ public class SiteUser {
     @Column(unique = true, nullable = false)
     private String providerId;
 
+    @Column(unique = true, nullable = false)
+    private String nickname;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private SiteUserRole role;
 
     protected SiteUser() {}
 
-    public SiteUser(String providerId) {
+    public SiteUser(String nickname, String providerId) {
+        this.nickname = nickname;
         this.providerId = providerId;
         this.role = SiteUserRole.ROLE_USER;
     }

--- a/src/main/java/online/pictz/api/user/infrastructure/NicknameApiClient.java
+++ b/src/main/java/online/pictz/api/user/infrastructure/NicknameApiClient.java
@@ -1,0 +1,7 @@
+package online.pictz.api.user.infrastructure;
+
+public interface NicknameApiClient {
+
+    String fetchNickname();
+
+}

--- a/src/main/java/online/pictz/api/user/infrastructure/NicknameResponse.java
+++ b/src/main/java/online/pictz/api/user/infrastructure/NicknameResponse.java
@@ -1,0 +1,21 @@
+package online.pictz.api.user.infrastructure;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class NicknameResponse {
+
+    private String msg;
+
+    private String code;
+
+    private String data;
+
+    public NicknameResponse(String msg, String code, String data) {
+        this.msg = msg;
+        this.code = code;
+        this.data = data;
+    }
+}

--- a/src/main/java/online/pictz/api/user/infrastructure/RandomNicknameClient.java
+++ b/src/main/java/online/pictz/api/user/infrastructure/RandomNicknameClient.java
@@ -1,0 +1,50 @@
+package online.pictz.api.user.infrastructure;
+
+import online.pictz.api.user.infrastructure.exception.NicknameClientException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class RandomNicknameClient implements NicknameApiClient {
+
+    private final RestTemplate restTemplate;
+    private final String nicknameApiUrl;
+
+    public RandomNicknameClient(RestTemplate restTemplate,
+        @Value("${nickname.api.url}") String nicknameApiUrl) {
+        this.restTemplate = restTemplate;
+        this.nicknameApiUrl = nicknameApiUrl;
+    }
+
+    @Override
+    public String fetchNickname() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("lang", "ko");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(formData, headers);
+
+        ResponseEntity<NicknameResponse> response = restTemplate.postForEntity(
+            nicknameApiUrl, request, NicknameResponse.class);
+
+        NicknameResponse nicknameResponse = response.getBody();
+
+        if (response.getStatusCode() == HttpStatus.OK
+            && response.getBody() != null
+            && "true".equalsIgnoreCase(nicknameResponse.getCode())) {
+            return nicknameResponse.getData();
+        } else {
+            throw NicknameClientException.of(nicknameResponse.getMsg(), nicknameResponse.getCode());
+        }
+    }
+}

--- a/src/main/java/online/pictz/api/user/infrastructure/exception/NicknameClientException.java
+++ b/src/main/java/online/pictz/api/user/infrastructure/exception/NicknameClientException.java
@@ -1,0 +1,26 @@
+package online.pictz.api.user.infrastructure.exception;
+
+import online.pictz.api.common.exception.domain.ErrorType;
+import online.pictz.api.common.exception.domain.PictzException;
+import org.springframework.http.HttpStatus;
+
+public class NicknameClientException extends PictzException {
+
+    public NicknameClientException(String message) {
+        super(message);
+    }
+
+    public static NicknameClientException of(String message, String code) {
+        return new NicknameClientException("Failed to request nickname from API: " + message + " (error code: " + code + ")");
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.UNAUTHORIZED;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ErrorType.UNAUTHORIZED.getCode();
+    }
+}

--- a/src/main/java/online/pictz/api/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/online/pictz/api/user/service/CustomOAuth2UserService.java
@@ -28,8 +28,10 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
 
-        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
-            .getUserInfoEndpoint().getUserNameAttributeName();
+        String userNameAttributeName = userRequest.getClientRegistration()
+            .getProviderDetails()
+            .getUserInfoEndpoint()
+            .getUserNameAttributeName();
 
         var attributes = oAuth2User.getAttributes();
 
@@ -42,7 +44,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 return siteUserRepository.save(newUser);
             });
 
-        return new CustomOAuth2User(siteUser, attributes);
+        return new CustomOAuth2User(siteUser);
     }
 
 }

--- a/src/main/java/online/pictz/api/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/online/pictz/api/user/service/CustomOAuth2UserService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final SiteUserRepository siteUserRepository;
+    private final NicknameGenerator nicknameGenerator;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -35,7 +36,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         String providerId = (String) attributes.get(userNameAttributeName);
 
         SiteUser siteUser = siteUserRepository.findByProviderId(providerId)
-            .orElseGet(() -> siteUserRepository.save(new SiteUser(providerId)));
+            .orElseGet(() -> {
+                String randomNickname = nicknameGenerator.generateNickname();
+                SiteUser newUser = new SiteUser(randomNickname, providerId);
+                return siteUserRepository.save(newUser);
+            });
 
         return new CustomOAuth2User(siteUser, attributes);
     }

--- a/src/main/java/online/pictz/api/user/service/NicknameGenerator.java
+++ b/src/main/java/online/pictz/api/user/service/NicknameGenerator.java
@@ -1,0 +1,19 @@
+package online.pictz.api.user.service;
+
+import lombok.RequiredArgsConstructor;
+import online.pictz.api.common.util.random.SuffixGenerator;
+import online.pictz.api.user.infrastructure.NicknameApiClient;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class NicknameGenerator {
+
+    private final NicknameApiClient nicknameApiClient;
+    private final SuffixGenerator suffixGenerator;
+
+    public String generateNickname() {
+        return nicknameApiClient.fetchNickname() + suffixGenerator.generateSuffix();
+    }
+
+}


### PR DESCRIPTION
- 랜덤 닉네임 API 호출
- 회원가입 시, 랜덤 닉네임으로 저장
- 시큐리티 컨텍스트 홀더 개인정보 저장 삭제
- 회원 프로필 API 구현