### PR TITLE
refactor/토픽 문의 허용 메서드 리팩토링

### DIFF
--- a/src/main/java/online/pictz/api/choice/entity/Choice.java
+++ b/src/main/java/online/pictz/api/choice/entity/Choice.java
@@ -1,5 +1,7 @@
 package online.pictz.api.choice.entity;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -8,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Version;
 import lombok.Getter;
+import online.pictz.api.topic.entity.TopicSuggestChoiceImage;
 
 @Getter
 @Entity
@@ -20,6 +23,9 @@ public class Choice {
 
     @Column(name = "topic_id", nullable = false)
     private Long topicId;
+
+    @Column(name = "suggest_choice_image_id", nullable = false)
+    private Long choiceImageId;
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -37,14 +43,47 @@ public class Choice {
 
     }
 
-    public Choice(Long topicId, String name, String imageUrl) {
+    public Choice(Long topicId, String name, String imageUrl, Long choiceImageId) {
         this.topicId = topicId;
         this.name = name;
         this.imageUrl = imageUrl;
-        this.voteCount = 0;
+        this.choiceImageId = choiceImageId;
     }
 
     public void updateVoteCount(int voteCount) {
         this.voteCount += voteCount;
     }
+
+    public void updateImageDetail(String imageUrl, String fileName) {
+        this.imageUrl = imageUrl;
+        this.name = fileName;
+    }
+
+    /**
+     * topicId에 대한 새로운 선택지 생성
+     * @param topicId 선택지의 부모 토픽
+     * @param images  선택지의 이미지
+     * @return 선택지
+     */
+    public static List<Choice> createFrom(Long topicId, List<TopicSuggestChoiceImage> images) {
+        return images.stream()
+            .map(image ->
+                new Choice(topicId, image.getFileName(), image.getImageUrl(), image.getId()))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 기존 선택지를 변경된 선택지 문의에 따라 이미지 정보 업데이트
+     * @param choices 저장되어있는 선택지 목록
+     * @param images  변경 요청온 선택지 목록 이미지 정보
+     */
+    public static void updateFrom(List<Choice> choices, List<TopicSuggestChoiceImage> images) {
+        images.forEach(image -> choices.stream()
+            .filter(choice -> choice.getId().equals(image.getId()))
+            .findFirst()
+            .ifPresent(choice -> choice.updateImageDetail(image.getImageUrl(), image.getFileName()))
+        );
+    }
+
+
 }

--- a/src/main/java/online/pictz/api/topic/entity/Topic.java
+++ b/src/main/java/online/pictz/api/topic/entity/Topic.java
@@ -40,11 +40,24 @@ public class Topic {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "total_vote_count", columnDefinition = "INT default 0")
+    private int totalVoteCount;
+
     protected Topic() {
     }
 
-    public void changeStatus(TopicStatus newStatus) {
-        this.status = newStatus;
+    public void approve(LocalDateTime updatedAt,String thumbnailImageUrl) {
+        this.status = TopicStatus.ACTIVE;
+        this.updatedAt = updatedAt;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
+
+    public void reject(LocalDateTime updatedAt) {
+        this.status = TopicStatus.INACTIVE;
+        this.updatedAt = updatedAt;
     }
 
     @Builder


### PR DESCRIPTION
- 토픽 활성화 / 비활성화 구분하도록 리팩토링
- 선택지 생성 / 업데이트 메서드 단위 메소드로 구현
- 토픽 문의 허용 시, 선택지 사진 업데이트 안되는 버그 수정