### PR TITLE
cleanup/토픽 문의 이미지 리스트 연관관계 설정 삭제

### DIFF
--- a/src/main/java/online/pictz/api/topic/dto/TopicSuggestCreate.java
+++ b/src/main/java/online/pictz/api/topic/dto/TopicSuggestCreate.java
@@ -1,0 +1,15 @@
+package online.pictz.api.topic.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@AllArgsConstructor
+@Getter
+public class TopicSuggestCreate {
+    private String title;
+    private String description;
+    private MultipartFile thumbnail;
+    private List<MultipartFile> choiceImages;
+}

--- a/src/main/java/online/pictz/api/topic/service/TopicSuggestService.java
+++ b/src/main/java/online/pictz/api/topic/service/TopicSuggestService.java
@@ -1,18 +1,19 @@
 package online.pictz.api.topic.service;
 
 import java.util.List;
+import online.pictz.api.topic.dto.TopicSuggestCreate;
 import online.pictz.api.topic.dto.TopicSuggestRequest;
 import online.pictz.api.topic.dto.TopicSuggestResponse;
 
 public interface TopicSuggestService {
 
-    TopicSuggestResponse createSuggest(Long siteUserId, TopicSuggestRequest suggestRequest);
+    TopicSuggestResponse createSuggest(Long siteUserId, TopicSuggestCreate createRequest);
 
     List<TopicSuggestResponse> getUserTopicSuggestList(Long userId);
 
     TopicSuggestResponse getUserTopicSuggestDetail(Long suggestId, Long userId);
 
-    TopicSuggestResponse updateTopicSuggest(Long topicSuggestId, Long userId,
-        TopicSuggestRequest suggestRequest);
+    TopicSuggestResponse updateTopicSuggest(Long suggestId, Long userId,
+        TopicSuggestRequest updateRequest);
 
 }


### PR DESCRIPTION
- 토픽 문의 선택지 이미지 리스트 연관관계 버그 발생 및 코드 변경에 따라 삭제
   - 이미지 정보를 업데이트 해야 하는데 "orphanRemoval = true"로 인하여 DB단에서 완전히 삭제되고 새로 생성되어서 PK값이 자동 증가 되어버림

- 토픽 문의 생성 dto 생성