### PR TITLE
refactor/투표 업데이트 로직 SRP에 따른 리팩토링

### DIFF
--- a/src/main/java/online/pictz/api/choice/dto/ChoiceResponse.java
+++ b/src/main/java/online/pictz/api/choice/dto/ChoiceResponse.java
@@ -16,7 +16,7 @@ public class ChoiceResponse {
         this.topicId = choice.getTopicId();
         this.name = choice.getName();
         this.imageUrl = choice.getImageUrl();
-        this.voteCount = choice.getVoteCount();
+        this.voteCount = choice.getCount();
         this.choiceId = choice.getId();
     }
 

--- a/src/main/java/online/pictz/api/choice/entity/Choice.java
+++ b/src/main/java/online/pictz/api/choice/entity/Choice.java
@@ -33,8 +33,8 @@ public class Choice {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
-    @Column(name = "vote_count", columnDefinition = "INT default 0")
-    private int voteCount;
+    @Column(name = "count", columnDefinition = "INT default 0")
+    private int count;
 
     @Version
     private int version;
@@ -50,8 +50,8 @@ public class Choice {
         this.choiceImageId = choiceImageId;
     }
 
-    public void updateVoteCount(int voteCount) {
-        this.voteCount += voteCount;
+    public void updateCount(int count) {
+        this.count += count;
     }
 
     public void updateImageDetail(String imageUrl, String fileName) {

--- a/src/main/java/online/pictz/api/choice/repository/dsl/ChoiceRepositoryImpl.java
+++ b/src/main/java/online/pictz/api/choice/repository/dsl/ChoiceRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ChoiceRepositoryImpl implements ChoiceRepositoryCustom{
         return queryFactory
             .select(Projections.constructor(ChoiceCountResponse.class,
                 choice.id,
-                choice.voteCount
+                choice.count
             ))
             .from(choice)
             .where(choice.id.in(choiceIds))

--- a/src/main/java/online/pictz/api/topic/service/TopicService.java
+++ b/src/main/java/online/pictz/api/topic/service/TopicService.java
@@ -1,6 +1,7 @@
 package online.pictz.api.topic.service;
 
 import java.util.List;
+import java.util.Map;
 import online.pictz.api.common.dto.PagedResponse;
 import online.pictz.api.topic.dto.TopicCountResponse;
 import online.pictz.api.topic.dto.TopicResponse;
@@ -13,4 +14,6 @@ public interface TopicService {
     List<TopicCountResponse> getAllTopicCounts(int page);
 
     PagedResponse<TopicResponse> searchTopics(String query, TopicSort sortBy, int page);
+
+    void updateTopicTotalCounts(Map<Long, Integer> topicVoteMap);
 }

--- a/src/main/java/online/pictz/api/topic/service/TopicServiceImpl.java
+++ b/src/main/java/online/pictz/api/topic/service/TopicServiceImpl.java
@@ -1,6 +1,7 @@
 package online.pictz.api.topic.service;
 
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import online.pictz.api.common.dto.PagedResponse;
@@ -8,6 +9,7 @@ import online.pictz.api.topic.dto.TopicCountResponse;
 import online.pictz.api.topic.dto.TopicResponse;
 import online.pictz.api.topic.entity.TopicSort;
 import online.pictz.api.topic.repository.TopicRepository;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,6 +71,24 @@ public class TopicServiceImpl implements TopicService{
             queryResult.getTotalPages(),
             queryResult.isLast()
         );
+    }
+
+    /**
+     * 토픽의 총 투표수 업데이트
+     *
+     * topicId
+     * @param topicVoteMap (topicId : count)
+     */
+    @Override
+    public void updateTopicTotalCounts(Map<Long, Integer> topicVoteMap) {
+        for (Map.Entry<Long, Integer> e : topicVoteMap.entrySet()) {
+            Long topicId = e.getKey();
+            Integer voteTotalCount = e.getValue();
+            int updatedRows = topicRepository.incrementTotalCount(topicId, voteTotalCount);
+            if (updatedRows == 0) {
+                throw new OptimisticLockingFailureException("Failed to update totalCount for Topic ID: " + topicId);
+            }
+        }
     }
 
 }

--- a/src/main/java/online/pictz/api/vote/service/VoteConverter.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteConverter.java
@@ -26,7 +26,7 @@ public class VoteConverter {
      * 투표 정보 목록 entity 로 변환
      */
     public List<Vote> convertToVoteEntities(List<VoteRequest> voteRequests, String ip, LocalDateTime voteAt) {
-        List<Vote> votesToSave = new ArrayList<>();
+        List<Vote> votes = new ArrayList<>();
         for (VoteRequest vote : voteRequests) {
             Vote voteEntity = Vote.builder()
                 .choiceId(vote.getChoiceId())
@@ -34,13 +34,14 @@ public class VoteConverter {
                 .ip(ip)
                 .votedAt(voteAt)
                 .build();
-            votesToSave.add(voteEntity);
+            votes.add(voteEntity);
         }
-        return votesToSave;
+        return votes;
     }
 
     /**
      * choiceId 별 투표 회수 Map 생성
+     * choiceId(1) : count(100)
      */
     public Map<Long, Integer> convertToVoteCountMap(List<VoteRequest> voteRequests) {
         Map<Long, Integer> voteCountMap = new ConcurrentHashMap<>();

--- a/src/main/java/online/pictz/api/vote/service/VoteProcessor.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteProcessor.java
@@ -1,0 +1,79 @@
+package online.pictz.api.vote.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import online.pictz.api.choice.entity.Choice;
+import online.pictz.api.vote.dto.VoteRequest;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class VoteProcessor {
+
+    private final VoteConverter voteConverter;
+
+    /**
+     * 선택지의 투표수를 업데이트
+     *
+     * @param choices      기존 선택지 목록
+     * @param voteRequests 투표 요청 목록
+     * @return 투표수가 업데이트된 선택지 목록
+     */
+    public List<Choice> updateChoiceCount(List<Choice> choices, List<VoteRequest> voteRequests) {
+
+        // (key: choiceId, value: Choice)
+        Map<Long, Choice> choiceMap = new HashMap<>();
+        for (Choice choice : choices) {
+            choiceMap.put(choice.getId(), choice);
+        }
+
+        // 투표 요청을 기반으로 선택지의 투표수 업데이트
+        for (VoteRequest vote : voteRequests) {
+            Choice choice = choiceMap.get(vote.getChoiceId());
+            if (choice != null) {
+                choice.updateCount(vote.getCount());
+            }
+        }
+
+        return new ArrayList<>(choiceMap.values());
+    }
+
+
+    /**
+     * 각 토픽별로 현재 투표에서 증가한 투표수 계산
+     *
+     * @param choices      기존 선택지 목록
+     * @param voteRequests 투표 요청 목록
+     * @return 토픽별 투표수 증가량 맵
+     */
+    public Map<Long, Integer> calculateTopicVoteTotalCount(List<Choice> choices,
+        List<VoteRequest> voteRequests) {
+
+        // 선택지 ID와 토픽 ID 매핑 (choiceId -> topicId)
+        Map<Long, Long> choiceToTopicMap = choices.stream()
+            .collect(Collectors.toMap(
+                Choice::getId,
+                Choice::getTopicId
+            ));
+
+        // 토픽별 투표수 증가량 계산
+        Map<Long, Integer> topicVoteTotalMap = new HashMap<>();
+        for (VoteRequest voteRequest : voteRequests) {
+            Long choiceId = voteRequest.getChoiceId();
+            Long topicId = choiceToTopicMap.get(choiceId);
+            int count = voteRequest.getCount();
+
+            if (topicId != null) {
+                topicVoteTotalMap.merge(topicId, count, Integer::sum);
+            }
+        }
+
+        return topicVoteTotalMap;
+    }
+
+
+}

--- a/src/main/java/online/pictz/api/vote/service/VoteServiceImpl.java
+++ b/src/main/java/online/pictz/api/vote/service/VoteServiceImpl.java
@@ -1,7 +1,6 @@
 package online.pictz.api.vote.service;
 
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +8,7 @@ import online.pictz.api.choice.entity.Choice;
 import online.pictz.api.choice.repository.ChoiceRepository;
 import online.pictz.api.common.util.network.IpExtractor;
 import online.pictz.api.common.util.time.TimeProvider;
-import online.pictz.api.topic.repository.TopicRepository;
+import online.pictz.api.topic.service.TopicService;
 import online.pictz.api.vote.dto.VoteRequest;
 import online.pictz.api.vote.entity.Vote;
 import online.pictz.api.vote.exception.VoteTooManyRequests;
@@ -28,9 +27,14 @@ public class VoteServiceImpl implements VoteService{
     private final TimeProvider timeProvider;
     private final VoteConverter voteConverter;
     private final VoteValidator voteValidator;
-    private final TopicRepository topicRepository;
+    private final VoteProcessor voteProcessor;
+    private final TopicService topicService;
     private static final int MAX_RETRY = 30;
 
+    /**
+     * 투표 저장
+     * @param voteRequests
+     */
     @Transactional
     @Override
     public void voteBulk(List<VoteRequest> voteRequests) {
@@ -40,41 +44,21 @@ public class VoteServiceImpl implements VoteService{
                 // 매크로 검증
                 voteValidator.validateVoteMacro(voteRequests);
 
-                // 요청한 선택지 ID 값 목록 추출
-                List<Long> choiceIds = voteConverter.convertToChoiceIds(voteRequests);
-                List<Choice> choices = choiceRepository.findAllById(choiceIds);
+                // 선택지별(Choice) 투표수 업데이트
+                List<Choice> existingChoices = getChoicesFromVoteRequest(voteRequests);
+                existingChoices = voteProcessor.updateChoiceCount(existingChoices, voteRequests);
+                choiceRepository.saveAll(existingChoices);
 
-                // 투표 수 choice ID에 맞게 업데이트
-                Map<Long, Integer> voteCountMap = voteConverter.convertToVoteCountMap(voteRequests);
+                // 토픽(Topic) 총 투표수 업데이트
+                Map<Long, Integer> topicVoteIncrements = voteProcessor.calculateTopicVoteTotalCount(existingChoices, voteRequests);
+                topicService.updateTopicTotalCounts(topicVoteIncrements);
 
-                // 토픽별 투표 수를 집계하기 위한 맵
-                Map<Long, Integer> topicVoteIncrementMap = new HashMap<>();
-
-                choices.forEach(choice -> {
-                    int countToAdd = voteCountMap.getOrDefault(choice.getId(),0);
-                    choice.updateVoteCount(countToAdd);
-
-                    Long topicId = choice.getTopicId();
-                    topicVoteIncrementMap.merge(topicId, countToAdd, Integer::sum);
-                });
-
-                choiceRepository.saveAll(choices);
-
-                // 토픽 total count 업데이트 (TODO : 배치나 레디스로 일정시간마다 업데이트 하는 방식으로 변경하는게 좋을 듯)
-                for (Map.Entry<Long, Integer> entry : topicVoteIncrementMap.entrySet()) {
-                    Long topicId = entry.getKey();
-                    Integer increment = entry.getValue();
-                    int updatedRows = topicRepository.incrementTotalCount(topicId, increment);
-                    if (updatedRows == 0) {
-                        throw new OptimisticLockingFailureException("Failed to update totalCount for Topic ID: " + topicId);
-                    }
-                }
-
-                // 투표 정보 저장
+                // 투표(Vote) 정보 저장
                 String ip = ipExtractor.extractIp();
-                List<Vote> votesToSave = voteConverter.convertToVoteEntities(voteRequests, ip, timeProvider.getCurrentTime());
+                List<Vote> votes = voteConverter.convertToVoteEntities(voteRequests, ip,
+                    timeProvider.getCurrentTime());
+                voteRepository.saveAll(votes);
 
-                voteRepository.saveAll(votesToSave);
                 break;
             } catch (OptimisticLockingFailureException e) {
                 ++retryCount;
@@ -83,5 +67,16 @@ public class VoteServiceImpl implements VoteService{
                 }
             }
         }
+    }
+
+    /**
+     * 투표 요청으로부터 선택지 목록 조회
+     *
+     * @param voteRequests 투표 요청 목록
+     * @return 선택지 목록
+     */
+    private List<Choice> getChoicesFromVoteRequest(List<VoteRequest> voteRequests) {
+        List<Long> choiceIds = voteConverter.convertToChoiceIds(voteRequests);
+        return choiceRepository.findAllById(choiceIds);
     }
 }

--- a/src/test/java/online/pictz/api/choice/entity/ChoiceTest.java
+++ b/src/test/java/online/pictz/api/choice/entity/ChoiceTest.java
@@ -22,11 +22,11 @@ class ChoiceTest {
     }
 
     @Test
-    void updateVoteCount() {
+    void updateCount() {
 
         // when
-        choice.updateVoteCount(10);
-        int result = choice.getVoteCount();
+        choice.updateCount(10);
+        int result = choice.getCount();
 
         // then
         assertThat(result).isEqualTo(10);


### PR DESCRIPTION
## 문제점
- 투표 업데이트 로직안에 너무나 많은 책임이 들어있음
- 이로 인해, 단위 테스트 시, 강제로 Mock해야하는 잘못된 코드 설계가 의심됨

## 해결 과정
- 선택지 count, 토픽 count 계산하는 voteProcessor로 책임 옮김
- 토픽 DB저장은 TopicService가 하도록 변경 함

---
- 선택지 count 컬럼명 단순화