### PR TITLE
캐싱 전략 – Redis vs Local Cache (Caffeine,Ehcache) 비교

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ application-dev.yml
 
 ### imges ###
 /uploads
+/storagePath
 
 ### Qclass ###
 /src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+
+	// CACHE
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/online/pictz/api/ApiApplication.java
+++ b/src/main/java/online/pictz/api/ApiApplication.java
@@ -2,7 +2,9 @@ package online.pictz.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class ApiApplication {
 

--- a/src/main/java/online/pictz/api/common/config/CacheConfig.java
+++ b/src/main/java/online/pictz/api/common/config/CacheConfig.java
@@ -1,0 +1,45 @@
+package online.pictz.api.common.config;
+
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    /**
+     * 인기순 토픽 캐시 설정
+     *
+     * @return Caffeine 빌더 설정
+     */
+    @Bean
+    public Caffeine<Object, Object> popularTopicsCaffeineConfig() {
+        return Caffeine.newBuilder()
+            .maximumSize(1000)
+            .expireAfterWrite(5, TimeUnit.SECONDS)
+            .recordStats();
+    }
+
+
+    /**
+     * 캐시 매니저 설정
+     *
+     * @return CacheManager 빈
+     */
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(List.of(
+            new CaffeineCache("popularTopics", popularTopicsCaffeineConfig().build())
+        ));
+        return cacheManager;
+    }
+}

--- a/src/main/java/online/pictz/api/topic/service/TopicServiceImpl.java
+++ b/src/main/java/online/pictz/api/topic/service/TopicServiceImpl.java
@@ -9,6 +9,7 @@ import online.pictz.api.topic.dto.TopicCountResponse;
 import online.pictz.api.topic.dto.TopicResponse;
 import online.pictz.api.topic.entity.TopicSort;
 import online.pictz.api.topic.repository.TopicRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -23,13 +24,20 @@ public class TopicServiceImpl implements TopicService{
 
     /**
      * 페이지에 해당하는 토픽 조회
+     *
      * @param sortType 정렬 조건
-     * @param page 현재 페이지
+     * @param page     현재 페이지
      * @return 토픽 목록
      */
     @Transactional(readOnly = true)
     @Override
+    @Cacheable(
+        value = "popularTopics",
+        key = "'POPULAR-' + #page", // 캐시 키: 'POPULAR-' + 페이지 번호
+        condition = "#sortType == T(online.pictz.api.topic.entity.TopicSort).POPULAR" // POPULAR 정렬일 때만 캐시 적용
+    )
     public PagedResponse<TopicResponse> getActiveTopics(TopicSort sortType, int page) {
+
         Page<TopicResponse> topicPage = topicRepository.findActiveTopics(sortType, page);
         return new PagedResponse<>(
             topicPage.getContent(),

--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 let currentSortBy = 'POPULAR';
 let currentPage = 0;
+let totalPages = 0;
 
 /**
  * Topics 목록 api 요청
@@ -169,7 +170,8 @@ function setupPagination() {
 /**
  * 페이징 정보 기반으로 페이지 네비게이션 UI 업데이트
  */
-function updatePagination(currentPage, totalPages) {
+function updatePagination(currentPage, totalPagesParam) {
+    totalPages = totalPagesParam;
     const pagination = document.querySelector('.pagination');
     pagination.innerHTML = ''; // 기존 페이지 버튼 초기화
 


### PR DESCRIPTION
# 🔍 **1. 문제**
- 사용자 경험 향상을 위한 메인 페이지 캐시 적용 도중 발생
- **메인 페이지 실시간 투표 반영 요구**
  - 캐시는 자주 변경되지 않는 데이터에 적용해야 효율적임
  - Redis, Caffeine, Ehcache를 비교하여, **Caffeine** 사용하기로 결정
  - BUT 어떻게 하면 효율적으로 적용할 수 있을지 고민

# 🚀 **2. Global Cache (Redis) VS Local Cache (Caffeine, Ehcache)**
**1. 로컬 캐시인 Caffeine Cache 선택**
- **단일 서버 환경**: Redis와 같은 글로벌 캐시는 비용 증가 및 네트워크를 이용하므로 속도 저하 → 로컬 캐시 선택
- **Ehcache vs Caffeine**
  - Caffeine은 LRU 정책 대신 Window-TinyLFU 알고리즘으로 99% 적중률 달성 (참고: [Caffeine Benchmark](https://github.com/ben-manes/caffeine/wiki/Benchmarks))
  - **투표 수 조회** 부분에 적용하므로, 조회 속도가 빠른 Caffeine Cache 선택

# 📚 **3-1. Caffeine VS Redis 부하 테스트**
- **테스트 환경 및 시나리오**
   -  Mac에서 VMware Fusion을 이용
   - 실제 EC2 Free Tier와 유사한 (예: CPU 1개, RAM 3GB Swap 이용) 환경에서 테스트 진행
   -  Caffeine : **Ubuntu 서버 2대 구성 (Tomcat, MySQL)**
   -  Redis : **Ubuntu 서버 3대 구성 (Tomcat, MySQL, Redis)**
### 3-2. Caffeine 부하 테스트 환경 구성도
![192 168 138 1355432](https://github.com/user-attachments/assets/0f6b39ef-2377-4022-881e-ea204f4dbb68)
### 3-3. Caffeine 부하 테스트 결과
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/3322af49-7bbf-4fd0-9a8a-80bfb45d7320" />

### 3-4. Redis 부하 테스트 환경 구성도
![Redis 조회 (1)](https://github.com/user-attachments/assets/e4b44425-05c3-4b91-b22e-e8938b9e223f)

### 3-5. Redis 부하 테스트 결과
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/cbb78583-42ea-43c4-ab44-70a1bd21b9b2" />


# 4. 테스트 결과 분석
- Caffeine
  - TPS: 328
  - 실행된 테스트 수 : 19,093
  - 성공한 테스트 수 : 19,084
  - 실패한 테스트 수 : 9
``` text plain
EC2 free tier와 유사한 낮은 사양으로 인해 JVM에서 Out Of Memory 발생으로 9건 에러
``` 

- Redis
  - TPS: 299
  - 실행된 테스트 수 : 19,093
  - 성공한 테스트 수 : 19,093
  - 실패한 테스트 수 : 0
``` text plain
 - 별도 Redis 서버 사용으로 오류 없이 안정적으로 동작
 - 네트워크 호출로 인해 응답 속도는 조금 더 느림 (아마 로컬 PC의 가상 머신이라 AWS 환경보단 더 빠른거 같음)
```

# 5. 캐시 만료 정책
``` java
.maximumSize(1000)          // 캐시 최대 크기를 1000으로 설정
.expireAfterWrite(5, SECONDS)  // 5초 후 만료로 실시간성 보장 
.recordStats();            
```
- 5초 TTL (Time-To-Live)
  - 사용자 투표 결과가 5초 이내 메인 페이지에 반영 → 5초 정도의 동기화가 사용자 경험에 있어서 괜찮다고 판단
  - 너무 짧은 TTL(1~2초)은 빈번한 DB 접근을 유발하고, 너무 긴 TTL(30초)은 실시간 투표 동기화에 문제 발생 → 5초로 결정

# 6 결론
- 단일 서버 환경이고, Redis를 사용하면, 비용이 추가 발생
- 사용자 요청이 많지 않은 관계로, Out Of Memory 발생은 거의 없음
- 아직은 로컬 캐시인 Caffeine Cache가 더 적합하다고 판단