### PR TITLE
feat/투표 in memory 성능 개선

### DIFF
--- a/src/main/java/online/pictz/api/ApiApplication.java
+++ b/src/main/java/online/pictz/api/ApiApplication.java
@@ -3,7 +3,9 @@ package online.pictz.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableCaching
 @SpringBootApplication
 public class ApiApplication {

--- a/src/main/java/online/pictz/api/choice/repository/ChoiceRepository.java
+++ b/src/main/java/online/pictz/api/choice/repository/ChoiceRepository.java
@@ -10,4 +10,6 @@ public interface ChoiceRepository extends JpaRepository<Choice, Long>, ChoiceRep
     List<Choice> findByTopicId(Long topicId);
 
     List<Choice> findByTopicIdIn(List<Long> topicIds);
+
+    List<Choice> findByIdIn(List<Long> choiceIds);
 }

--- a/src/main/java/online/pictz/api/vote/controller/VoteApiController.java
+++ b/src/main/java/online/pictz/api/vote/controller/VoteApiController.java
@@ -19,9 +19,17 @@ public class VoteApiController {
 
     /**
      * 투표 일괄 처리
+     * 멀티쓰레드 동시성 문제 및 요청마다 DB 쓰기로 인한 과부하 발생
      */
-    @PostMapping("/bulk")
+    @Deprecated
+    @PostMapping
     public ResponseEntity<Void> voteBulk(@RequestBody List<VoteRequest> voteRequest) {
+        voteService.voteBulk(voteRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<Void> voteBulkInMemory(@RequestBody List<VoteRequest> voteRequest) {
         voteService.voteBulk(voteRequest);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/online/pictz/api/vote/service/test/InMemoryChoiceStorage.java
+++ b/src/main/java/online/pictz/api/vote/service/test/InMemoryChoiceStorage.java
@@ -1,0 +1,67 @@
+package online.pictz.api.vote.service.test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InMemoryChoiceStorage {
+
+    // 멀티 쓰레드 안전
+    private final ConcurrentHashMap<Long, AtomicInteger> choiceStorage = new ConcurrentHashMap<>();
+
+    /**
+     * 메모리에 선택지 투표 임시 저장
+     * @param choiceId 선택할 선택지 ID
+     * @param count 투표 수
+     */
+    public void store(Long choiceId, int count) {
+        if (count <= 0) {
+            return;
+        }
+        // KEY 없다면 생성 후 VALUE : 0 설정
+        AtomicInteger atomicInteger = choiceStorage.computeIfAbsent(choiceId,
+            id -> new AtomicInteger(0));
+
+        // 해당 KEY VALUE 증가
+        atomicInteger.addAndGet(count);
+    }
+
+    /**
+     * 메모리에 있는 선택지 리턴 후, 메모리 초기화
+     * @return choiceId : count
+     */
+    public Map<Long, Integer> getAndClearStorage() {
+
+        Map<Long, Integer> inMemoryStorage = new HashMap<>();
+
+        for (Map.Entry<Long, AtomicInteger> entry : choiceStorage.entrySet()) {
+            Long choiceId = entry.getKey();
+            int count = entry.getValue().getAndSet(0);
+            if (count > 0) {
+                inMemoryStorage.put(choiceId, count);
+            }
+        }
+        return inMemoryStorage;
+    }
+
+    /**
+     * 특정 선택지들의 현재 투표 수를 반환
+     * @param choiceIds 조회 할 선택지 ID
+     * @return 요청된 선택지 ID와 해당 투표 수의 맵
+     */
+    public Map<Long, Integer> getCurrentCounts(List<Long> choiceIds) {
+        Map<Long, Integer> currentCounts = new HashMap<>();
+        for (Long choiceId : choiceIds) {
+            AtomicInteger count = choiceStorage.get(choiceId);
+            if (count != null) {
+                currentCounts.put(choiceId, count.get());
+            }
+        }
+        return currentCounts;
+    }
+
+}

--- a/src/main/java/online/pictz/api/vote/service/test/VoteBatch.java
+++ b/src/main/java/online/pictz/api/vote/service/test/VoteBatch.java
@@ -1,0 +1,63 @@
+package online.pictz.api.vote.service.test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import online.pictz.api.choice.entity.Choice;
+import online.pictz.api.choice.repository.ChoiceRepository;
+import online.pictz.api.common.util.time.TimeProvider;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class VoteBatch {
+
+    private final VoteBatchProcessor voteBatchProcessor;
+    private final ChoiceRepository choiceRepository;
+    private final TimeProvider timeProvider;
+    private final InMemoryChoiceStorage choiceStorage;
+
+    @Scheduled(fixedRate = 15000)
+    @Transactional
+    public void processBatchVotes() {
+
+        log.info("Start the vote batch...");
+        // 인 메모리 투표 결과 가져오기
+        Map<Long, Integer> inMemoryChoices = choiceStorage.getAndClearStorage();
+        if (inMemoryChoices.isEmpty()) {
+            log.info("There is no voting data in memory");
+            log.info("Exit the batch");
+            return;
+        }
+
+        List<Long> requestedChoiceIds = new ArrayList<>(inMemoryChoices.keySet());
+
+        // DB 존재하지 않는 선택지 필터링
+        List<Choice> existsChoices = choiceRepository.findByIdIn(requestedChoiceIds);
+        Map<Long, Integer> existsChoicesMap = new HashMap<>();
+
+        for (Choice choice : existsChoices) {
+            Long choiceId = choice.getId();
+            if (inMemoryChoices.containsKey(choiceId)) {
+                Integer count = inMemoryChoices.get(choiceId);
+                existsChoicesMap.put(choiceId, count);
+            }
+        }
+
+        if (existsChoicesMap.isEmpty()) {
+            return;
+        }
+
+        voteBatchProcessor.updateChoices(existsChoicesMap);
+        voteBatchProcessor.updateTopic(existsChoicesMap, existsChoices);
+        voteBatchProcessor.insertVoteRecords(existsChoicesMap, timeProvider.getCurrentTime());
+
+    }
+
+}

--- a/src/main/java/online/pictz/api/vote/service/test/VoteBatchProcessor.java
+++ b/src/main/java/online/pictz/api/vote/service/test/VoteBatchProcessor.java
@@ -1,0 +1,179 @@
+package online.pictz.api.vote.service.test;
+
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import online.pictz.api.choice.entity.Choice;
+import online.pictz.api.common.util.time.TimeProvider;
+import online.pictz.api.vote.entity.Vote;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VoteBatchProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(VoteBatchProcessor.class);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TimeProvider timeProvider;
+
+    public VoteBatchProcessor(JdbcTemplate jdbcTemplate, TimeProvider timeProvider) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.timeProvider = timeProvider;
+    }
+
+    /**
+     * UPDATE choice SET count = CASE id WHEN 1 THEN count + 10 WHEN 2 THEN count + 20 ... END WHERE
+     * id IN (1, 2)
+     */
+    public void updateChoices(Map<Long, Integer> existsChoicesMap) {
+
+        log.info("Starting updateChoices with {} entries, TIME {}", existsChoicesMap.size(),timeProvider.getCurrentTime());
+
+        StringBuilder sb = new StringBuilder();
+        StringJoiner joiner = new StringJoiner(", ");
+
+        List<Object> params = new ArrayList<>();
+        List<Long> ids = new ArrayList<>();
+
+        sb.append("UPDATE choice SET count = CASE id ");
+
+        for (Map.Entry<Long, Integer> entry : existsChoicesMap.entrySet()) {
+            Long choiceId = entry.getKey();
+            int count = entry.getValue();
+            sb.append("WHEN ").append(choiceId).append(" THEN count + ? ");
+            params.add(count);
+            ids.add(choiceId);
+        }
+
+        sb.append("END WHERE id IN (");
+        for (Long id : ids) {
+            joiner.add("?");
+        }
+
+        sb.append(joiner).append(")");
+
+        params.addAll(ids);
+        String sql = sb.toString();
+        try {
+            jdbcTemplate.update(sql, params.toArray());
+            log.info("Successfully updated {} choices", existsChoicesMap.size());
+        } catch (Exception e) {
+            log.error("Failed to update choices with ids {}. Error: {}", ids, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * UPDATE topic SET total_count = CASE id WHEN 1 THEN total_count + 100 WHEN 2 THEN total_count
+     * + 200 END  WHERE id IN (1, 2)
+     */
+    public void updateTopic(Map<Long, Integer> existsChoicesMap, List<Choice> choices) {
+        log.info("Starting updateTopic with {} entries and {} choices, TIME {}",
+            existsChoicesMap.size(), choices.size(), timeProvider.getCurrentTime());
+
+        // [choiceID : topicID]
+        Map<Long, Long> choiceToTopic = choices.stream()
+            .collect(Collectors.toMap(
+                Choice::getId,
+                Choice::getTopicId
+            ));
+
+        Map<Long, Integer> topicTotalCount = new HashMap<>();
+        for (Map.Entry<Long, Integer> entry : existsChoicesMap.entrySet()) {
+            Long choiceId = entry.getKey();
+            Integer count = entry.getValue();
+            Long topicId = choiceToTopic.get(choiceId);
+
+            if (topicId != null) {
+                topicTotalCount.merge(topicId, count, Integer::sum);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        StringJoiner joiner = new StringJoiner(", ");
+
+        List<Object> params = new ArrayList<>();
+        List<Long> ids = new ArrayList<>();
+
+        sb.append("UPDATE topic SET total_count = CASE id ");
+        for (Map.Entry<Long, Integer> entry : topicTotalCount.entrySet()) {
+            Long topicId = entry.getKey();
+            Integer count = entry.getValue();
+
+            sb.append("WHEN ").append(topicId).append(" THEN total_count + ? ");
+            params.add(count);
+
+            ids.add(topicId);
+        }
+
+        sb.append("END WHERE id IN (");
+        for (Long id : ids) {
+            joiner.add("?");
+        }
+
+        sb.append(joiner).append(")");
+        params.addAll(ids);
+        String sql = sb.toString();
+        try {
+            jdbcTemplate.update(sql, params.toArray());
+            log.info("Successfully updated {} topics", topicTotalCount.size());
+        } catch (Exception e) {
+            log.error("Failed to update topics with ids {}. Error: {}", ids, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * INSERT INTO vote (choice_id, count, voted_at, ip) VALUES (?, ?, ?, ?), (?, ?, ?, ?)...
+     */
+    public void insertVoteRecords(Map<Long, Integer> existsChoicesMap,
+        LocalDateTime votedAt) {
+
+        log.info("Starting insertVoteRecords with {} entries, TIME: {}", existsChoicesMap.size(), votedAt);
+
+        List<Vote> votes = new ArrayList<>();
+        for (Map.Entry<Long, Integer> entry : existsChoicesMap.entrySet()) {
+            Long choiceId = entry.getKey();
+            Integer count = entry.getValue();
+            votes.add(
+                Vote.builder()
+                    .choiceId(choiceId)
+                    .count(count)
+                    .votedAt(votedAt)
+                    .build()
+            );
+        }
+
+        String sql = "INSERT INTO vote (choice_id, count, voted_at) VALUES (?, ?, ?)";
+
+        int[] batchSize = jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(@NonNull PreparedStatement ps, int i) throws SQLException {
+                Vote vote = votes.get(i);
+                ps.setLong(1, vote.getChoiceId());
+                ps.setInt(2, vote.getCount());
+                ps.setTimestamp(3, Timestamp.valueOf(vote.getVotedAt()));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return votes.size();
+            }
+
+        });
+        log.info("Successfully inserted {} vote records into the database.", batchSize.length);
+    }
+}

--- a/src/main/java/online/pictz/api/vote/service/test/VoteInMemoryService.java
+++ b/src/main/java/online/pictz/api/vote/service/test/VoteInMemoryService.java
@@ -1,0 +1,24 @@
+package online.pictz.api.vote.service.test;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import online.pictz.api.vote.dto.VoteRequest;
+import online.pictz.api.vote.service.VoteService;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Primary
+@RequiredArgsConstructor
+@Service
+public class VoteInMemoryService implements VoteService {
+
+    private final InMemoryChoiceStorage choiceStorage;
+
+    @Override
+    public void voteBulk(List<VoteRequest> voteRequests) {
+        for (VoteRequest request : voteRequests) {
+            choiceStorage.store(request.getChoiceId(), request.getCount());
+        }
+    }
+
+}

--- a/src/test/java/online/pictz/api/vote/service/test/VoteInMemoryServiceTest.java
+++ b/src/test/java/online/pictz/api/vote/service/test/VoteInMemoryServiceTest.java
@@ -1,0 +1,42 @@
+package online.pictz.api.vote.service.test;
+
+import java.util.List;
+import online.pictz.api.vote.dto.VoteRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class VoteInMemoryServiceTest {
+
+    @Autowired
+    VoteInMemoryService voteInMemoryService;
+
+    @Autowired
+    VoteBatch voteBatch;
+    @Test
+    void test() {
+        Long choiceId1 = 1L;
+        Long choiceId2 = 2L;
+        Long choiceId3 = 3L;
+
+        int count1 = 10;
+        int count2 = 20;
+        int count3 = 30;
+
+        List<VoteRequest> voteRequests = List.of(
+            new VoteRequest(choiceId1, count1),
+            new VoteRequest(choiceId2, count2),
+            new VoteRequest(choiceId3, count3)
+        );
+
+        voteInMemoryService.voteBulk(
+            voteRequests
+        );
+
+        voteBatch.processBatchVotes();
+    }
+
+}


### PR DESCRIPTION
# 투표 정보 DB 저장 인 메모리로 변경
#95 문제점을 개선하기 위해 투표 시, 바로 DB저장이 아닌 메모리에 담아뒀다가 일정시간마다 batch 로 DB 일괄처리


## 성능 차이
<img width="725" alt="image" src="https://github.com/user-attachments/assets/1d467fa7-5795-4a96-bcee-6459274d553b">

<img width="806" alt="image" src="https://github.com/user-attachments/assets/35432d11-a433-4ef9-b8a5-c660b4d89b14">

TPS 약 16배 개선